### PR TITLE
Add explicit permissions to all tx

### DIFF
--- a/app/containers/BuyRam/saga.js
+++ b/app/containers/BuyRam/saga.js
@@ -1,5 +1,8 @@
 import { takeLatest, put, select, all } from 'redux-saga/effects';
-import EosClient, { makeSelectEosAccount as EosAccount } from 'containers/Scatter/selectors';
+import EosClient, {
+  makeSelectEosAuthority as EosAuthority,
+  makeSelectEosAccount as EosAccount,
+} from 'containers/Scatter/selectors';
 import { failureNotification, loadingNotification, successNotification } from 'containers/Notification/actions';
 import Form from './selectors';
 import { DEFAULT_ACTION } from './constants';
@@ -11,6 +14,7 @@ function* performAction() {
   const eosClient = yield select(EosClient());
   const form = yield select(Form());
   const eosAccount = yield select(EosAccount());
+  const eosAuth = yield select(EosAuthority());
   yield put(loadingNotification());
   try {
     const res = yield eosClient.transaction(tr => {
@@ -20,7 +24,8 @@ function* performAction() {
         quant: `${Number(form.quantity)
           .toFixed(4)
           .toString()} EOS`,
-      });
+      },
+      { authorization: [{ actor: eosAccount, permission: eosAuth }] });
     });
     yield put(successNotification(res.transaction_id));
   } catch (err) {

--- a/app/containers/BuyRamBytes/saga.js
+++ b/app/containers/BuyRamBytes/saga.js
@@ -1,5 +1,8 @@
 import { takeLatest, put, select, all } from 'redux-saga/effects';
-import EosClient, { makeSelectEosAccount as EosAccount } from 'containers/Scatter/selectors';
+import EosClient, {
+  makeSelectEosAuthority as EosAuthority,
+  makeSelectEosAccount as EosAccount,
+} from 'containers/Scatter/selectors';
 import { failureNotification, loadingNotification, successNotification } from 'containers/Notification/actions';
 
 import Form from './selectors';
@@ -12,6 +15,7 @@ function* performAction() {
   const eosClient = yield select(EosClient());
   const form = yield select(Form());
   const eosAccount = yield select(EosAccount());
+  const eosAuth = yield select(EosAuthority());
   yield put(loadingNotification());
   try {
     const res = yield eosClient.transaction(tr => {
@@ -19,7 +23,8 @@ function* performAction() {
         payer: eosAccount,
         receiver: form.name,
         bytes: Number(form.ram),
-      });
+      },
+      { authorization: [{ actor: eosAccount, permission: eosAuth }] });
     });
     yield put(successNotification(res.transaction_id));
   } catch (err) {

--- a/app/containers/ClaimRewards/saga.js
+++ b/app/containers/ClaimRewards/saga.js
@@ -1,5 +1,8 @@
 import { takeLatest, put, select, all } from 'redux-saga/effects';
-import EosClient, { makeSelectEosAccount as EosAccount } from 'containers/Scatter/selectors';
+import EosClient, {
+  makeSelectEosAuthority as EosAuthority,
+  makeSelectEosAccount as EosAccount,
+} from 'containers/Scatter/selectors';
 import { failureNotification, loadingNotification, successNotification } from 'containers/Notification/actions';
 import { DEFAULT_ACTION } from './constants';
 
@@ -9,12 +12,14 @@ import { DEFAULT_ACTION } from './constants';
 function* performAction() {
   const eosClient = yield select(EosClient());
   const eosAccount = yield select(EosAccount());
+  const eosAuth = yield select(EosAuthority());
   yield put(loadingNotification());
   try {
     const res = yield eosClient.transaction(tr => {
       tr.claimrewards({
         owner: eosAccount,
-      });
+      },
+      { authorization: [{ actor: eosAccount, permission: eosAuth }] });
     });
     yield put(successNotification(res.transaction_id));
   } catch (err) {

--- a/app/containers/CreateAccount/saga.js
+++ b/app/containers/CreateAccount/saga.js
@@ -1,5 +1,8 @@
 import { takeLatest, put, select, all } from 'redux-saga/effects';
-import EosClient, { makeSelectEosAccount as EosAccount } from 'containers/Scatter/selectors';
+import EosClient, {
+  makeSelectEosAuthority as EosAuthority,
+  makeSelectEosAccount as EosAccount,
+} from 'containers/Scatter/selectors';
 import { failureNotification, loadingNotification, successNotification } from 'containers/Notification/actions';
 
 import Form from './selectors';
@@ -12,6 +15,7 @@ function* performAction() {
   const eosClient = yield select(EosClient());
   const form = yield select(Form());
   const eosAccount = yield select(EosAccount());
+  const eosAuth = yield select(EosAuthority());
   yield put(loadingNotification());
   try {
     const res = yield eosClient.transaction(tr => {
@@ -20,12 +24,14 @@ function* performAction() {
         name: form.name,
         owner: form.ownerKey,
         active: form.activeKey,
-      });
+      },
+      { authorization: [{ actor: eosAccount, permission: eosAuth }] });
       tr.buyrambytes({
         payer: eosAccount,
         receiver: form.name,
         bytes: Number(form.ram),
-      });
+      },
+      { authorization: [{ actor: eosAccount, permission: eosAuth }] });
       tr.delegatebw({
         from: eosAccount,
         receiver: form.name,
@@ -36,7 +42,8 @@ function* performAction() {
           .toFixed(4)
           .toString()} EOS`,
         transfer: form.transfer ? 1 : 0,
-      });
+      },
+      { authorization: [{ actor: eosAccount, permission: eosAuth }] });
     });
     yield put(successNotification(res.transaction_id));
   } catch (err) {

--- a/app/containers/CreateProxy/saga.js
+++ b/app/containers/CreateProxy/saga.js
@@ -1,5 +1,8 @@
 import { takeLatest, put, select, all } from 'redux-saga/effects';
-import EosClient, { makeSelectEosAccount as EosAccount } from 'containers/Scatter/selectors';
+import EosClient, {
+  makeSelectEosAuthority as EosAuthority,
+  makeSelectEosAccount as EosAccount,
+} from 'containers/Scatter/selectors';
 import { failureNotification, loadingNotification, successNotification } from 'containers/Notification/actions';
 import Form from './selectors';
 import { DEFAULT_ACTION } from './constants';
@@ -11,13 +14,15 @@ function* performAction() {
   const eosClient = yield select(EosClient());
   const form = yield select(Form());
   const eosAccount = yield select(EosAccount());
+  const eosAuth = yield select(EosAuthority());
   yield put(loadingNotification());
   try {
     const res = yield eosClient.transaction(tr => {
       tr.regproxy({
         proxy: eosAccount,
         isproxy: form.isProxy ? 1 : 0,
-      });
+      },
+      { authorization: [{ actor: eosAccount, permission: eosAuth }] });
     });
     yield put(successNotification(res.transaction_id));
   } catch (err) {

--- a/app/containers/Delegate/saga.js
+++ b/app/containers/Delegate/saga.js
@@ -1,5 +1,8 @@
 import { takeLatest, put, select, all } from 'redux-saga/effects';
-import EosClient, { makeSelectEosAccount as EosAccount } from 'containers/Scatter/selectors';
+import EosClient, {
+  makeSelectEosAuthority as EosAuthority,
+  makeSelectEosAccount as EosAccount,
+} from 'containers/Scatter/selectors';
 import { failureNotification, loadingNotification, successNotification } from 'containers/Notification/actions';
 
 import Form from './selectors';
@@ -14,6 +17,7 @@ function* performAction() {
   const form = yield select(Form());
   // console.log(form);
   const eosAccount = yield select(EosAccount());
+  const eosAuth = yield select(EosAuthority());
   yield put(loadingNotification());
   try {
     const res = yield eosClient.transaction(tr => {
@@ -27,7 +31,8 @@ function* performAction() {
           .toFixed(4)
           .toString()} EOS`,
         transfer: form.transfer ? 1 : 0,
-      });
+      },
+      { authorization: [{ actor: eosAccount, permission: eosAuth }] });
     });
     yield put(successNotification(res.transaction_id));
   } catch (err) {

--- a/app/containers/Refund/saga.js
+++ b/app/containers/Refund/saga.js
@@ -1,5 +1,8 @@
 import { takeLatest, put, select, all } from 'redux-saga/effects';
-import EosClient, { makeSelectEosAccount as EosAccount } from 'containers/Scatter/selectors';
+import EosClient, {
+  makeSelectEosAuthority as EosAuthority,
+  makeSelectEosAccount as EosAccount,
+} from 'containers/Scatter/selectors';
 import { failureNotification, loadingNotification, successNotification } from 'containers/Notification/actions';
 // import Form from './selectors';
 import { DEFAULT_ACTION } from './constants';
@@ -11,12 +14,14 @@ function* performAction() {
   const eosClient = yield select(EosClient());
   // const form = yield select(Form());
   const eosAccount = yield select(EosAccount());
+  const eosAuth = yield select(EosAuthority());
   yield put(loadingNotification());
   try {
     const res = yield eosClient.transaction(tr => {
       tr.refund({
         owner: eosAccount,
-      });
+      },
+      { authorization: [{ actor: eosAccount, permission: eosAuth }] });
     });
     yield put(successNotification(res.transaction_id));
   } catch (err) {

--- a/app/containers/SellRam/saga.js
+++ b/app/containers/SellRam/saga.js
@@ -1,5 +1,8 @@
 import { takeLatest, put, select, all } from 'redux-saga/effects';
-import EosClient, { makeSelectEosAccount as EosAccount } from 'containers/Scatter/selectors';
+import EosClient, {
+  makeSelectEosAuthority as EosAuthority,
+  makeSelectEosAccount as EosAccount,
+} from 'containers/Scatter/selectors';
 import { failureNotification, loadingNotification, successNotification } from 'containers/Notification/actions';
 import Form from './selectors';
 import { DEFAULT_ACTION } from './constants';
@@ -11,13 +14,15 @@ function* performAction() {
   const eosClient = yield select(EosClient());
   const form = yield select(Form());
   const eosAccount = yield select(EosAccount());
+    const eosAuth = yield select(EosAuthority());
   yield put(loadingNotification());
   try {
     const res = yield eosClient.transaction(tr => {
       tr.sellram({
         account: eosAccount,
         bytes: Number(form.ram),
-      });
+      },
+      { authorization: [{ actor: eosAccount, permission: eosAuth }] });
     });
     yield put(successNotification(res.transaction_id));
   } catch (err) {

--- a/app/containers/SetProxy/saga.js
+++ b/app/containers/SetProxy/saga.js
@@ -1,5 +1,8 @@
 import { takeLatest, put, select, all } from 'redux-saga/effects';
-import EosClient, { makeSelectEosAccount as EosAccount } from 'containers/Scatter/selectors';
+import EosClient, {
+  makeSelectEosAuthority as EosAuthority,
+  makeSelectEosAccount as EosAccount,
+} from 'containers/Scatter/selectors';
 import { failureNotification, loadingNotification, successNotification } from 'containers/Notification/actions';
 import Form from './selectors';
 import { DEFAULT_ACTION } from './constants';
@@ -11,13 +14,15 @@ function* performAction() {
   const eosClient = yield select(EosClient());
   const form = yield select(Form());
   const eosAccount = yield select(EosAccount());
+  const eosAuth = yield select(EosAuthority());
   yield put(loadingNotification());
   try {
     const res = yield eosClient.transaction(tr => {
       tr.voteproducer({
         voter: eosAccount,
         proxy: form.name,
-      });
+      },
+      { authorization: [{ actor: eosAccount, permission: eosAuth }] });
     });
     yield put(successNotification(res.transaction_id));
   } catch (err) {

--- a/app/containers/Transfer/saga.js
+++ b/app/containers/Transfer/saga.js
@@ -1,5 +1,8 @@
 import { takeLatest, put, select, all } from 'redux-saga/effects';
-import EosClient, { makeSelectEosAccount as EosAccount } from 'containers/Scatter/selectors';
+import EosClient, {
+  makeSelectEosAuthority as EosAuthority,
+  makeSelectEosAccount as EosAccount,
+} from 'containers/Scatter/selectors';
 import { failureNotification, loadingNotification, successNotification } from 'containers/Notification/actions';
 import Form from './selectors';
 import { DEFAULT_ACTION } from './constants';
@@ -11,6 +14,7 @@ function* performAction() {
   const eosClient = yield select(EosClient());
   const form = yield select(Form());
   const eosAccount = yield select(EosAccount());
+  const eosAuth = yield select(EosAuthority());
   yield put(loadingNotification());
   try {
     const res = yield eosClient.transfer({
@@ -21,7 +25,8 @@ function* performAction() {
         .toFixed(4)
         .toString()} EOS`,
       memo: form.memo,
-    });
+    },
+    { authorization: [{ actor: eosAccount, permission: eosAuth }] });
     yield put(successNotification(res.transaction_id));
   } catch (err) {
     yield put(failureNotification(err));

--- a/app/containers/Undelegate/saga.js
+++ b/app/containers/Undelegate/saga.js
@@ -1,5 +1,8 @@
 import { takeLatest, put, select, all } from 'redux-saga/effects';
-import EosClient, { makeSelectEosAccount as EosAccount } from 'containers/Scatter/selectors';
+import EosClient, {
+  makeSelectEosAuthority as EosAuthority,
+  makeSelectEosAccount as EosAccount,
+} from 'containers/Scatter/selectors';
 import { failureNotification, loadingNotification, successNotification } from 'containers/Notification/actions';
 import Form from './selectors';
 import { DEFAULT_ACTION } from './constants';
@@ -11,6 +14,7 @@ function* performAction() {
   const eosClient = yield select(EosClient());
   const form = yield select(Form());
   const eosAccount = yield select(EosAccount());
+  const eosAuth = yield select(EosAuthority());
   yield put(loadingNotification());
   try {
     const res = yield eosClient.transaction(tr => {
@@ -23,7 +27,8 @@ function* performAction() {
         unstake_cpu_quantity: `${Number(form.cpu)
           .toFixed(4)
           .toString()} EOS`,
-      });
+      },
+      { authorization: [{ actor: eosAccount, permission: eosAuth }] });
     });
     yield put(successNotification(res.transaction_id));
   } catch (err) {

--- a/app/containers/VoteUs/saga.js
+++ b/app/containers/VoteUs/saga.js
@@ -1,5 +1,8 @@
 import { takeLatest, put, select, all } from 'redux-saga/effects';
-import EosClient, { makeSelectEosAccount as EosAccount } from 'containers/Scatter/selectors';
+import EosClient, {
+  makeSelectEosAuthority as EosAuthority,
+  makeSelectEosAccount as EosAccount,
+} from 'containers/Scatter/selectors';
 import { failureNotification, loadingNotification, successNotification } from 'containers/Notification/actions';
 import { DEFAULT_ACTION } from './constants';
 
@@ -9,6 +12,7 @@ import { DEFAULT_ACTION } from './constants';
 function* performAction() {
   const eosClient = yield select(EosClient());
   const eosAccount = yield select(EosAccount());
+  const eosAuth = yield select(EosAuthority());
 
   yield put(loadingNotification());
   try {
@@ -27,7 +31,8 @@ function* performAction() {
           voter: eosAccount,
           proxy: '',
           producers,
-        });
+        },
+        { authorization: [{ actor: eosAccount, permission: eosAuth }] });
       });
       yield put(successNotification(res.transaction_id));
     }


### PR DESCRIPTION
Scatter seems to default to active permission even if owner is selected. If the owner/active keys aren't the same this fails. Added explicit permission setting for all txs