### PR TITLE
Allow the owner field to be changeable to allow for account based perms

### DIFF
--- a/app/components/BuyRamForm/index.js
+++ b/app/components/BuyRamForm/index.js
@@ -40,7 +40,6 @@ import buyRamFormStyle from './buyRamFormStyle';
 const FormObject = props => {
   const {
     classes,
-    eosAccount,
     errors,
     handleBlur,
     handleChange,
@@ -85,19 +84,18 @@ const FormObject = props => {
         <GridItem xs={12} sm={12} md={6}>
           <CustomInput
             labelText="Payer"
-            id="creator"
-            error={errors.creator}
-            touched={touched.creator}
+            id="owner"
+            error={errors.owner}
+            touched={touched.owner}
             formControlProps={{
               fullWidth: true,
             }}
             inputProps={{
               type: 'text',
-              placeholder: 'Scatter account',
-              value: eosAccount,
+              placeholder: 'Account that pays for ram',
+              value: values.owner,
               onChange: handleChange,
               onBlur: handleBlur,
-              disabled: true,
             }}
           />
         </GridItem>
@@ -162,6 +160,7 @@ const validationSchema = ({ unit: { isEOS } }) => {
     .integer('RAM cannot be fractional');
 
   return Yup.object().shape({
+    owner: Yup.string().required('Payer name is required'),
     name: Yup.string().required('Account name is required'),
     byteQuantity: isEOS ? byteQuantity : byteQuantity.required('RAM purchase is required'),
     eosQuantity: !isEOS ? eosQuantity : eosQuantity.required('RAM purchase is required'),
@@ -169,7 +168,7 @@ const validationSchema = ({ unit: { isEOS } }) => {
 };
 
 const BuyRamForm = props => {
-  const { classes, eosAccount, handleSubmit, unit, ...formikProps } = props;
+  const { classes, handleSubmit, unit, ...formikProps } = props;
   const { errors, handleBlur, handleChange, submitForm, touched, values } = formikProps;
   return (
     <GridContainer>
@@ -184,7 +183,6 @@ const BuyRamForm = props => {
           <CardBody>
             <FormObject
               classes={classes}
-              eosAccount={eosAccount}
               errors={errors}
               handleBlur={handleBlur}
               handleChange={handleChange}
@@ -224,7 +222,7 @@ const enhance = compose(
     },
     mapPropsToValues: props => ({
       byteQuantity: 8192,
-      creator: '',
+      owner: props.eosAccount,
       eosQuantity: 1,
       isEOS: props.unit.isEOS,
       name: '',

--- a/app/components/ClaimRewardsForm/index.js
+++ b/app/components/ClaimRewardsForm/index.js
@@ -26,7 +26,7 @@ import CardBody from 'components/Card/CardBody';
 import regularFormsStyle from 'assets/jss/regularFormsStyle';
 
 const FormObject = props => {
-  const { touched, errors, handleChange, handleBlur, handleSubmit, eosAccount } = props;
+  const { touched, errors, handleChange, handleBlur, handleSubmit, values } = props;
   return (
     <form>
       <GridContainer>
@@ -41,11 +41,10 @@ const FormObject = props => {
             }}
             inputProps={{
               type: 'text',
-              placeholder: 'Scatter account',
-              value: eosAccount,
+              placeholder: 'Account that claims',
+              value: values.owner,
               onChange: handleChange,
               onBlur: handleBlur,
-              disabled: true,
             }}
           />
         </GridItem>
@@ -80,11 +79,10 @@ const ClaimRewardsForm = props => {
           <CardBody>
             <Formik
               initialValues={{
-                owner: '',
+                owner: eosAccount,
               }}
               onSubmit={handleSubmit}
-              eosAccount={eosAccount}
-              render={formikProps => <FormObject {...formikProps} eosAccount={eosAccount} classes={classes} />}
+              render={formikProps => <FormObject {...formikProps} classes={classes} />}
             />
           </CardBody>
         </Card>

--- a/app/components/CreateAccountForm/index.js
+++ b/app/components/CreateAccountForm/index.js
@@ -32,7 +32,7 @@ import CardBody from 'components/Card/CardBody';
 import regularFormsStyle from 'assets/jss/regularFormsStyle';
 
 const FormObject = props => {
-  const { values, touched, errors, handleChange, handleBlur, handleSubmit, eosAccount, classes } = props;
+  const { values, touched, errors, handleChange, handleBlur, handleSubmit, classes } = props;
   return (
     <form>
       <GridContainer>
@@ -56,20 +56,19 @@ const FormObject = props => {
         </GridItem>
         <GridItem xs={12} sm={12} md={6}>
           <CustomInput
-            labelText="Creator"
-            id="creator"
-            error={errors.creator}
-            touched={touched.creator}
+            labelText="owner"
+            id="owner"
+            error={errors.owner}
+            touched={touched.owner}
             formControlProps={{
               fullWidth: true,
             }}
             inputProps={{
               type: 'text',
-              placeholder: 'Scatter account',
-              value: eosAccount,
+              placeholder: 'Account that performs action',
+              value: values.owner,
               onChange: handleChange,
               onBlur: handleBlur,
-              disabled: true,
             }}
           />
         </GridItem>
@@ -166,7 +165,7 @@ const FormObject = props => {
         <GridItem xs={12} sm={12} md={6}>
           <Tooltip
             id="tooltip-right"
-            title="Tranfer Off: Creator retains staking control and voting rights. Transfer On: New account gains staking control and voting rights."
+            title="Tranfer Off: owner retains staking control and voting rights. Transfer On: New account gains staking control and voting rights."
             placement="right"
             classes={{ tooltip: classes.formTooltip }}>
             <FormControlLabel
@@ -211,6 +210,7 @@ const FormObject = props => {
 };
 
 const validationSchema = Yup.object().shape({
+  owner: Yup.string().required('Creator name is required'),
   name: Yup.string()
     .required('Account name is required')
     .matches(/([a-z1-5]){12,}/, {
@@ -246,7 +246,7 @@ const CreateAccountForm = props => {
           <CardBody>
             <Formik
               initialValues={{
-                creator: '',
+                owner: eosAccount,
                 name: '',
                 ownerKey: '',
                 activeKey: '',
@@ -256,8 +256,7 @@ const CreateAccountForm = props => {
               }}
               validationSchema={validationSchema}
               onSubmit={handleSubmit}
-              eosAccount={eosAccount}
-              render={formikProps => <FormObject {...formikProps} eosAccount={eosAccount} classes={classes} />}
+              render={formikProps => <FormObject {...formikProps} classes={classes} />}
             />
           </CardBody>
         </Card>
@@ -275,7 +274,7 @@ const CreateAccountForm = props => {
               The <i>newaccount</i> action creates a new account.
               <br />
               <br />
-              As an authorized party I <i>signer</i> wish to exercise the authority of <i>creator</i> to create a new
+              As an authorized party I <i>signer</i> wish to exercise the authority of <i>owner</i> to create a new
               account on this system named <i>name</i> such that the new account&apos;s owner public key shall be{' '}
               <i>owner key</i> and the active public key shall be <i>active key</i>.
             </p>

--- a/app/components/CreateProxyForm/index.js
+++ b/app/components/CreateProxyForm/index.js
@@ -32,26 +32,25 @@ import CardBody from 'components/Card/CardBody';
 import regularFormsStyle from 'assets/jss/regularFormsStyle';
 
 const FormObject = props => {
-  const { values, touched, errors, handleChange, handleBlur, handleSubmit, eosAccount, classes } = props;
+  const { values, touched, errors, handleChange, handleBlur, handleSubmit, classes } = props;
   return (
     <form>
       <GridContainer>
         <GridItem xs={12} sm={12} md={8}>
           <CustomInput
-            labelText="Creator"
-            id="creator"
-            error={errors.creator}
-            touched={touched.creator}
+            labelText="owner"
+            id="owner"
+            error={errors.owner}
+            touched={touched.owner}
             formControlProps={{
               fullWidth: true,
             }}
             inputProps={{
               type: 'text',
-              placeholder: 'Scatter account',
-              value: eosAccount,
+              placeholder: 'Account that becomes proxy',
+              value: values.owner,
               onChange: handleChange,
               onBlur: handleBlur,
-              disabled: true,
             }}
           />
         </GridItem>
@@ -120,13 +119,12 @@ const CreateProxyForm = props => {
           <CardBody>
             <Formik
               initialValues={{
-                creator: '',
+                owner: eosAccount,
                 isProxy: false,
               }}
               validationSchema={validationSchema}
               onSubmit={handleSubmit}
-              eosAccount={eosAccount}
-              render={formikProps => <FormObject {...formikProps} eosAccount={eosAccount} classes={classes} />}
+              render={formikProps => <FormObject {...formikProps} classes={classes} />}
             />
           </CardBody>
         </Card>

--- a/app/components/DelegateForm/index.js
+++ b/app/components/DelegateForm/index.js
@@ -32,7 +32,7 @@ import CardBody from 'components/Card/CardBody';
 import regularFormsStyle from 'assets/jss/regularFormsStyle';
 
 const FormObject = props => {
-  const { values, touched, errors, handleChange, handleBlur, handleSubmit, eosAccount, classes } = props;
+  const { values, touched, errors, handleChange, handleBlur, handleSubmit, classes } = props;
   return (
     <form>
       <GridContainer>
@@ -57,19 +57,18 @@ const FormObject = props => {
         <GridItem xs={12} sm={12} md={6}>
           <CustomInput
             labelText="Stake Owner"
-            id="creator"
-            error={errors.creator}
-            touched={touched.creator}
+            id="owner"
+            error={errors.owner}
+            touched={touched.owner}
             formControlProps={{
               fullWidth: true,
             }}
             inputProps={{
               type: 'text',
-              placeholder: 'Scatter account',
-              value: eosAccount,
+              placeholder: 'Account that controls the stake',
+              value: values.owner,
               onChange: handleChange,
               onBlur: handleBlur,
-              disabled: true,
             }}
           />
         </GridItem>
@@ -112,7 +111,7 @@ const FormObject = props => {
         <GridItem xs={12} sm={12} md={6}>
           <Tooltip
             id="tooltip-right"
-            title="Tranfer Off: Creator retains staking control and voting rights. Transfer On: New account gains staking control and voting rights."
+            title="Tranfer Off: owner retains staking control and voting rights. Transfer On: New account gains staking control and voting rights."
             placement="right"
             classes={{ tooltip: classes.formTooltip }}>
             <FormControlLabel
@@ -157,6 +156,7 @@ const FormObject = props => {
 };
 
 const validationSchema = Yup.object().shape({
+  owner: Yup.string().required('Owner name is required'),
   name: Yup.string().required('Account name is required'),
   net: Yup.number()
     .required('NET Stake is required')
@@ -183,15 +183,14 @@ const DelegateForm = props => {
           <CardBody>
             <Formik
               initialValues={{
-                creator: '',
+                owner: eosAccount,
                 name: '',
                 net: '0',
                 cpu: '0',
               }}
               validationSchema={validationSchema}
               onSubmit={handleSubmit}
-              eosAccount={eosAccount}
-              render={formikProps => <FormObject {...formikProps} eosAccount={eosAccount} classes={classes} />}
+              render={formikProps => <FormObject {...formikProps} classes={classes} />}
             />
           </CardBody>
         </Card>

--- a/app/components/RefundForm/index.js
+++ b/app/components/RefundForm/index.js
@@ -25,7 +25,7 @@ import CardBody from 'components/Card/CardBody';
 import regularFormsStyle from 'assets/jss/regularFormsStyle';
 
 const FormObject = props => {
-  const { touched, errors, handleChange, handleBlur, handleSubmit, eosAccount } = props;
+  const { touched, errors, handleChange, handleBlur, handleSubmit, values } = props;
   return (
     <form>
       <GridContainer>
@@ -40,11 +40,10 @@ const FormObject = props => {
             }}
             inputProps={{
               type: 'text',
-              placeholder: 'Scatter account',
-              value: eosAccount,
+              placeholder: 'Account that receives the refund',
+              value: values.owner,
               onChange: handleChange,
               onBlur: handleBlur,
-              disabled: true,
             }}
           />
         </GridItem>
@@ -73,11 +72,10 @@ const RefundForm = props => {
           <CardBody>
             <Formik
               initialValues={{
-                owner: '',
+                owner: eosAccount,
               }}
               onSubmit={handleSubmit}
-              eosAccount={eosAccount}
-              render={formikProps => <FormObject {...formikProps} eosAccount={eosAccount} classes={classes} />}
+              render={formikProps => <FormObject {...formikProps} classes={classes} />}
             />
           </CardBody>
         </Card>

--- a/app/components/SellRamForm/index.js
+++ b/app/components/SellRamForm/index.js
@@ -29,26 +29,25 @@ import CardBody from 'components/Card/CardBody';
 import regularFormsStyle from 'assets/jss/regularFormsStyle';
 
 const FormObject = props => {
-  const { values, touched, errors, handleChange, handleBlur, handleSubmit, eosAccount } = props;
+  const { values, touched, errors, handleChange, handleBlur, handleSubmit } = props;
   return (
     <form>
       <GridContainer>
         <GridItem xs={12} sm={12} md={6}>
           <CustomInput
             labelText="Seller"
-            id="creator"
-            error={errors.creator}
-            touched={touched.creator}
+            id="owner"
+            error={errors.owner}
+            touched={touched.owner}
             formControlProps={{
               fullWidth: true,
             }}
             inputProps={{
               type: 'text',
-              placeholder: 'Scatter account',
-              value: eosAccount,
+              placeholder: 'Account that sells the Ram',
+              value: values.owner,
               onChange: handleChange,
               onBlur: handleBlur,
-              disabled: true,
             }}
           />
         </GridItem>
@@ -87,6 +86,7 @@ const FormObject = props => {
 };
 
 const validationSchema = Yup.object().shape({
+  owner: Yup.string().required('Buyer name is required'),
   ram: Yup.number()
     .required('RAM quantity is required')
     .positive('RAM must be a positive quantity')
@@ -108,14 +108,13 @@ const SellRamForm = props => {
           <CardBody>
             <Formik
               initialValues={{
-                creator: '',
+                owner: eosAccount,
                 name: '',
                 ram: '8192',
               }}
               validationSchema={validationSchema}
               onSubmit={handleSubmit}
-              eosAccount={eosAccount}
-              render={formikProps => <FormObject {...formikProps} eosAccount={eosAccount} classes={classes} />}
+              render={formikProps => <FormObject {...formikProps} classes={classes} />}
             />
           </CardBody>
         </Card>

--- a/app/components/SetProxyForm/index.js
+++ b/app/components/SetProxyForm/index.js
@@ -29,7 +29,7 @@ import CardBody from 'components/Card/CardBody';
 import regularFormsStyle from 'assets/jss/regularFormsStyle';
 
 const FormObject = props => {
-  const { values, touched, errors, handleChange, handleBlur, handleSubmit, eosAccount } = props;
+  const { values, touched, errors, handleChange, handleBlur, handleSubmit } = props;
   return (
     <form>
       <GridContainer>
@@ -53,20 +53,19 @@ const FormObject = props => {
         </GridItem>
         <GridItem xs={12} sm={12} md={6}>
           <CustomInput
-            labelText="Creator"
-            id="creator"
-            error={errors.creator}
-            touched={touched.creator}
+            labelText="Proxied Account Name"
+            id="owner"
+            error={errors.owner}
+            touched={touched.owner}
             formControlProps={{
               fullWidth: true,
             }}
             inputProps={{
               type: 'text',
-              placeholder: 'Scatter account',
-              value: eosAccount,
+              placeholder: 'Account that will be proxied',
+              value: values.owner,
               onChange: handleChange,
               onBlur: handleBlur,
-              disabled: true,
             }}
           />
         </GridItem>
@@ -88,6 +87,7 @@ const FormObject = props => {
 };
 
 const validationSchema = Yup.object().shape({
+  owner: Yup.string().required('Proxied name is required'),
   name: Yup.string().required('Account name is required'),
 });
 
@@ -108,13 +108,12 @@ const SetProxyForm = props => {
           <CardBody>
             <Formik
               initialValues={{
-                creator: '',
+                owner: eosAccount,
                 name: '',
               }}
               validationSchema={validationSchema}
               onSubmit={handleSubmit}
-              eosAccount={eosAccount}
-              render={formikProps => <FormObject {...formikProps} eosAccount={eosAccount} classes={classes} />}
+              render={formikProps => <FormObject {...formikProps} classes={classes} />}
             />
           </CardBody>
         </Card>

--- a/app/components/SimplePermissionsForm/index.js
+++ b/app/components/SimplePermissionsForm/index.js
@@ -29,26 +29,25 @@ import CardBody from 'components/Card/CardBody';
 import regularFormsStyle from 'assets/jss/regularFormsStyle';
 
 const FormObject = props => {
-  const { values, touched, errors, handleChange, handleBlur, handleSubmit, eosAccount } = props;
+  const { values, touched, errors, handleChange, handleBlur, handleSubmit } = props;
   return (
     <form>
       <GridContainer>
         <GridItem xs={12} sm={12} md={12}>
           <CustomInput
             labelText="Change permission on"
-            id="creator"
-            error={errors.creator}
-            touched={touched.creator}
+            id="owner"
+            error={errors.owner}
+            touched={touched.owner}
             formControlProps={{
               fullWidth: true,
             }}
             inputProps={{
               type: 'text',
-              placeholder: 'Scatter account',
-              value: eosAccount,
+              placeholder: 'Account whose permissions will change',
+              value: values.owner,
               onChange: handleChange,
               onBlur: handleBlur,
-              disabled: true,
             }}
           />
         </GridItem>
@@ -105,6 +104,7 @@ const FormObject = props => {
 };
 
 const validationSchema = Yup.object().shape({
+  owner: Yup.string().required('Owner name is required'),
   activeKey: Yup.string(),
   ownerKey: Yup.string(),
 });
@@ -124,14 +124,13 @@ const SimplePermissionsForm = props => {
           <CardBody>
             <Formik
               initialValues={{
-                creator: '',
+                owner: eosAccount,
                 activeKey: '',
                 ownerKey: '',
               }}
               validationSchema={validationSchema}
               onSubmit={handleSubmit}
-              eosAccount={eosAccount}
-              render={formikProps => <FormObject {...formikProps} eosAccount={eosAccount} classes={classes} />}
+              render={formikProps => <FormObject {...formikProps} classes={classes} />}
             />
           </CardBody>
         </Card>

--- a/app/components/TransferForm/index.js
+++ b/app/components/TransferForm/index.js
@@ -29,7 +29,7 @@ import CardBody from 'components/Card/CardBody';
 import regularFormsStyle from 'assets/jss/regularFormsStyle';
 
 const FormObject = props => {
-  const { values, touched, errors, handleChange, handleBlur, handleSubmit, eosAccount } = props;
+  const { values, touched, errors, handleChange, handleBlur, handleSubmit } = props;
   return (
     <form>
       <GridContainer>
@@ -44,7 +44,7 @@ const FormObject = props => {
             }}
             inputProps={{
               type: 'text',
-              placeholder: 'The account that receives the EOS',
+              placeholder: 'Account that receives the Token',
               value: values.name,
               onChange: handleChange,
               onBlur: handleBlur,
@@ -54,25 +54,24 @@ const FormObject = props => {
         <GridItem xs={12} sm={12} md={6}>
           <CustomInput
             labelText="Sender"
-            id="creator"
-            error={errors.creator}
-            touched={touched.creator}
+            id="owner"
+            error={errors.owner}
+            touched={touched.owner}
             formControlProps={{
               fullWidth: true,
             }}
             inputProps={{
               type: 'text',
-              placeholder: 'Scatter account',
-              value: eosAccount,
+              placeholder: 'Account that sends the Token',
+              value: values.owner,
               onChange: handleChange,
               onBlur: handleBlur,
-              disabled: true,
             }}
           />
         </GridItem>
         <GridItem xs={12} sm={12} md={6}>
           <CustomInput
-            labelText="Quantity (in EOS)"
+            labelText="Quantity (in Tokens)"
             id="quantity"
             error={errors.quantity}
             touched={touched.quantity}
@@ -81,7 +80,7 @@ const FormObject = props => {
             }}
             inputProps={{
               type: 'text',
-              placeholder: 'How much EOS to send',
+              placeholder: 'How many Tokens to send',
               value: values.quantity,
               onChange: handleChange,
               onBlur: handleBlur,
@@ -123,6 +122,7 @@ const FormObject = props => {
 };
 
 const validationSchema = Yup.object().shape({
+  owner: Yup.string().required('Sender name is required'),
   name: Yup.string().required('Account name is required'),
   memo: Yup.string(),
   quantity: Yup.number()
@@ -145,15 +145,14 @@ const TransferForm = props => {
           <CardBody>
             <Formik
               initialValues={{
-                creator: '',
+                owner: eosAccount,
                 name: '',
                 quantity: '0',
                 memo: '',
               }}
               validationSchema={validationSchema}
               onSubmit={handleSubmit}
-              eosAccount={eosAccount}
-              render={formikProps => <FormObject {...formikProps} eosAccount={eosAccount} classes={classes} />}
+              render={formikProps => <FormObject {...formikProps} classes={classes} />}
             />
           </CardBody>
         </Card>

--- a/app/components/UndelegateForm/index.js
+++ b/app/components/UndelegateForm/index.js
@@ -29,7 +29,7 @@ import CardBody from 'components/Card/CardBody';
 import regularFormsStyle from 'assets/jss/regularFormsStyle';
 
 const FormObject = props => {
-  const { values, touched, errors, handleChange, handleBlur, handleSubmit, eosAccount } = props;
+  const { values, touched, errors, handleChange, handleBlur, handleSubmit } = props;
   return (
     <form>
       <GridContainer>
@@ -54,19 +54,18 @@ const FormObject = props => {
         <GridItem xs={12} sm={12} md={6}>
           <CustomInput
             labelText="Stake Owner"
-            id="creator"
-            error={errors.creator}
-            touched={touched.creator}
+            id="owner"
+            error={errors.owner}
+            touched={touched.owner}
             formControlProps={{
               fullWidth: true,
             }}
             inputProps={{
               type: 'text',
-              placeholder: 'Scatter account',
-              value: eosAccount,
+              placeholder: 'Account that controls the stake',
+              value: values.owner,
               onChange: handleChange,
               onBlur: handleBlur,
-              disabled: true,
             }}
           />
         </GridItem>
@@ -123,6 +122,7 @@ const FormObject = props => {
 };
 
 const validationSchema = Yup.object().shape({
+  owner: Yup.string().required('Owner name is required'),
   name: Yup.string().required('Account name is required'),
   net: Yup.number()
     .required('NET Stake is required')
@@ -150,15 +150,14 @@ const UndelegateForm = props => {
             <h5>Unstaking takes three days. Unstaking lowers your vote weight immediately</h5>
             <Formik
               initialValues={{
-                creator: '',
+                owner: eosAccount,
                 name: '',
                 net: '0',
                 cpu: '0',
               }}
               validationSchema={validationSchema}
               onSubmit={handleSubmit}
-              eosAccount={eosAccount}
-              render={formikProps => <FormObject {...formikProps} eosAccount={eosAccount} classes={classes} />}
+              render={formikProps => <FormObject {...formikProps} classes={classes} />}
             />
           </CardBody>
         </Card>

--- a/app/containers/BuyRam/saga.js
+++ b/app/containers/BuyRam/saga.js
@@ -27,11 +27,11 @@ function* performAction() {
   }
 }
 
-function buyRAM({ eosClient, eosAccount, eosAuth, form: { name, eosQuantity } }) {
+function buyRAM({ eosClient, eosAccount, eosAuth, form: { owner, name, eosQuantity } }) {
   return eosClient.transaction(tr => {
     tr.buyram(
       {
-        payer: eosAccount,
+        payer: owner,
         receiver: name,
         quant: `${Number(eosQuantity)
           .toFixed(4)
@@ -42,11 +42,11 @@ function buyRAM({ eosClient, eosAccount, eosAuth, form: { name, eosQuantity } })
   });
 }
 
-function buyRAMBytes({ eosClient, eosAccount, eosAuth, form: { name, byteQuantity } }) {
+function buyRAMBytes({ eosClient, eosAccount, eosAuth, form: { owner, name, byteQuantity } }) {
   return eosClient.transaction(tr => {
     tr.buyrambytes(
       {
-        payer: eosAccount,
+        payer: owner,
         receiver: name,
         bytes: Number(byteQuantity),
       },

--- a/app/containers/ClaimRewards/saga.js
+++ b/app/containers/ClaimRewards/saga.js
@@ -5,7 +5,7 @@ import EosClient, {
 } from 'containers/Scatter/selectors';
 import { failureNotification, loadingNotification, successNotification } from 'containers/Notification/actions';
 import { DEFAULT_ACTION } from './constants';
-
+import Form from './selectors';
 //
 // Get the EOS Client once Scatter loads
 //
@@ -13,12 +13,13 @@ function* performAction() {
   const eosClient = yield select(EosClient());
   const eosAccount = yield select(EosAccount());
   const eosAuth = yield select(EosAuthority());
+  const form = yield select(Form());
   yield put(loadingNotification());
   try {
     const res = yield eosClient.transaction(tr => {
       tr.claimrewards(
         {
-          owner: eosAccount,
+          owner: form.owner,
         },
         { authorization: [{ actor: eosAccount, permission: eosAuth }] }
       );

--- a/app/containers/CreateAccount/saga.js
+++ b/app/containers/CreateAccount/saga.js
@@ -21,7 +21,7 @@ function* performAction() {
     const res = yield eosClient.transaction(tr => {
       tr.newaccount(
         {
-          creator: eosAccount,
+          creator: form.owner,
           name: form.name,
           owner: form.ownerKey,
           active: form.activeKey,
@@ -30,7 +30,7 @@ function* performAction() {
       );
       tr.buyrambytes(
         {
-          payer: eosAccount,
+          payer: form.creator,
           receiver: form.name,
           bytes: Number(form.ram),
         },
@@ -38,7 +38,7 @@ function* performAction() {
       );
       tr.delegatebw(
         {
-          from: eosAccount,
+          from: form.creator,
           receiver: form.name,
           stake_net_quantity: `${Number(form.net)
             .toFixed(4)

--- a/app/containers/CreateProxy/saga.js
+++ b/app/containers/CreateProxy/saga.js
@@ -20,7 +20,7 @@ function* performAction() {
     const res = yield eosClient.transaction(tr => {
       tr.regproxy(
         {
-          proxy: eosAccount,
+          proxy: form.owner,
           isproxy: form.isProxy ? 1 : 0,
         },
         { authorization: [{ actor: eosAccount, permission: eosAuth }] }

--- a/app/containers/Delegate/saga.js
+++ b/app/containers/Delegate/saga.js
@@ -23,7 +23,7 @@ function* performAction() {
     const res = yield eosClient.transaction(tr => {
       tr.delegatebw(
         {
-          from: eosAccount,
+          from: form.owner,
           receiver: form.name,
           stake_net_quantity: `${Number(form.net)
             .toFixed(4)

--- a/app/containers/Refund/saga.js
+++ b/app/containers/Refund/saga.js
@@ -4,15 +4,14 @@ import EosClient, {
   makeSelectEosAccount as EosAccount,
 } from 'containers/Scatter/selectors';
 import { failureNotification, loadingNotification, successNotification } from 'containers/Notification/actions';
-// import Form from './selectors';
+import Form from './selectors';
 import { DEFAULT_ACTION } from './constants';
-
 //
 // Get the EOS Client once Scatter loads
 //
 function* performAction() {
   const eosClient = yield select(EosClient());
-  // const form = yield select(Form());
+  const form = yield select(Form());
   const eosAccount = yield select(EosAccount());
   const eosAuth = yield select(EosAuthority());
   yield put(loadingNotification());
@@ -20,7 +19,7 @@ function* performAction() {
     const res = yield eosClient.transaction(tr => {
       tr.refund(
         {
-          owner: eosAccount,
+          owner: form.owner,
         },
         { authorization: [{ actor: eosAccount, permission: eosAuth }] }
       );

--- a/app/containers/SellRam/saga.js
+++ b/app/containers/SellRam/saga.js
@@ -20,7 +20,7 @@ function* performAction() {
     const res = yield eosClient.transaction(tr => {
       tr.sellram(
         {
-          account: eosAccount,
+          account: form.owner,
           bytes: Number(form.ram),
         },
         { authorization: [{ actor: eosAccount, permission: eosAuth }] }

--- a/app/containers/SetProxy/saga.js
+++ b/app/containers/SetProxy/saga.js
@@ -20,7 +20,7 @@ function* performAction() {
     const res = yield eosClient.transaction(tr => {
       tr.voteproducer(
         {
-          voter: eosAccount,
+          voter: form.owner,
           proxy: form.name,
         },
         { authorization: [{ actor: eosAccount, permission: eosAuth }] }

--- a/app/containers/SimplePermissions/saga.js
+++ b/app/containers/SimplePermissions/saga.js
@@ -21,7 +21,7 @@ function* performAction() {
       if (form.activeKey) {
         tr.updateauth(
           {
-            account: eosAccount,
+            account: form.owner,
             permission: 'active',
             parent: 'owner',
             auth: form.activeKey,
@@ -32,7 +32,7 @@ function* performAction() {
       if (form.ownerKey) {
         tr.updateauth(
           {
-            account: eosAccount,
+            account: form.owner,
             permission: 'owner',
             parent: '',
             auth: form.ownerKey,

--- a/app/containers/Transfer/saga.js
+++ b/app/containers/Transfer/saga.js
@@ -20,7 +20,7 @@ function* performAction() {
     const res = yield eosClient.transfer(
       {
         account: 'eosio.token',
-        from: eosAccount,
+        from: form.owner,
         to: form.name,
         quantity: `${Number(form.quantity)
           .toFixed(4)

--- a/app/containers/Undelegate/saga.js
+++ b/app/containers/Undelegate/saga.js
@@ -20,7 +20,7 @@ function* performAction() {
     const res = yield eosClient.transaction(tr => {
       tr.undelegatebw(
         {
-          from: eosAccount,
+          from: form.owner,
           receiver: form.name,
           unstake_net_quantity: `${Number(form.net)
             .toFixed(4)


### PR DESCRIPTION
People are starting to use more complex permission structures.

In the case where an "account" based permission is used the "action account" (called owner throughout, perhaps a better word is needed) may be different from the "scatter account".

To achieve this the fields have made editable, verification schema have been added, and the default value is set to the scatter account instead of locking it in. The downside to this is that scatter changes don't re-update the forms... but maybe that's ok (because they need to change scatter to appropriate authorising account).